### PR TITLE
Use microsecond timer for frame time for stable 60 fps

### DIFF
--- a/tunnelclient/Cargo.lock
+++ b/tunnelclient/Cargo.lock
@@ -42,6 +42,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,7 +78,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.1.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -81,7 +86,7 @@ name = "bytes"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -175,7 +180,7 @@ version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -186,6 +191,19 @@ dependencies = [
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -214,7 +232,7 @@ name = "dwmapi-sys"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -291,7 +309,7 @@ name = "gdi32-sys"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -411,7 +429,7 @@ name = "image"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gif 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jpeg-decoder 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -462,7 +480,7 @@ name = "jpeg-decoder"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -492,7 +510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.0.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -689,6 +707,14 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "num-traits"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,7 +901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston-viewport 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -917,9 +943,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand"
@@ -974,33 +1016,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "regex-syntax"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rmp"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rmp-serde"
-version = "0.13.7"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rusttype"
@@ -1049,13 +1116,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "serde"
 version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.18"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1107,7 +1187,7 @@ name = "shell32-sys"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1167,6 +1247,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "synom"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,7 +1291,7 @@ name = "thread_local"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1239,17 +1329,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "tunnelclient"
 version = "0.1.0"
 dependencies = [
+ "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hostname 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "interpolation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston2d-graphics 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston2d-opengl_graphics 0.49.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston_window 0.73.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pistoncore-glutin_window 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pistoncore-sdl2_window 0.46.0 (git+https://github.com/PistonDevelopers/sdl2_window)",
  "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp-serde 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple-error 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "streaming-stats 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1261,6 +1352,11 @@ dependencies = [
 [[package]]
 name = "unicode-xid"
 version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1276,7 +1372,7 @@ name = "user32-sys"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1354,7 +1450,7 @@ name = "wayland-window"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-protocols 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1490,13 +1586,14 @@ dependencies = [
 "checksum android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
 "checksum arrayvec 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2f0ef4a9820019a0c91d918918c93dc71d469f581a49b47ddc1d285d4270bbe2"
 "checksum async-dnssd 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bbf013011927ec3250bf41158d1141d54450d7b62bc355fe0f2f4b575b05f93e"
+"checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5cde24d1b2e2216a726368b2363a273739c91f4e3eb4e0dd12d672d396ad989"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 "checksum byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96c8b41881888cc08af32d47ac4edd52bc7fa27fef774be47a92443756451304"
-"checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
+"checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7db437d718977f6dc9b2e3fd6fc343c02ac6b899b73fdd2179163447bd9ce9"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum cgl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "86765cb42c2a2c497e142af72517c1b4d7ae5bb2f25dfa77a5c69642f2342d89"
@@ -1510,6 +1607,7 @@ dependencies = [
 "checksum core-graphics 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9797d894882bbf37c0c1218a8d90333fae3c6b09d526534fd370aac2bc6efc21"
 "checksum deflate 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4dddda59aaab719767ab11d3efd9a714e95b610c4445d4435765021e9d52dfb1"
 "checksum derivative 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67b3d6d0e84e53a5bdc263cc59340541877bb541706a191d762bfac6a481bdde"
+"checksum derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a141330240c921ec6d074a3e188a7c7ef95668bb95e7d44fa0e5778ec2a7afe"
 "checksum dlib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "148bce4ce1c36c4509f29cb54e62c2bd265551a9b00b38070fad551a851866ec"
 "checksum draw_state 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "337aeb4ca88f60f29e2e01ff252ac4eb40b9a86c65f699bdf4c7e3944390cea9"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -1546,7 +1644,7 @@ dependencies = [
 "checksum khronos_api 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "292227cfb1e811f7e974c427753fc8539394c6370a6849899306eedf2a478579"
 "checksum khronos_api 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d5a08e2a31d665af8f1ca437eab6d00a93c9d62a549f73f9ed8fc2e55b5a91a7"
 "checksum lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
-"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "5ba3df4dcb460b9dfbd070d41c94c19209620c191b0340b929ce748a2bcd42d2"
 "checksum libloading 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0a020ac941774eb37e9d13d418c37b522e76899bfc4e7b1a600d529a53f83a66"
@@ -1569,6 +1667,7 @@ dependencies = [
 "checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"
 "checksum num-rational 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "288629c76fac4b33556f4b7ab57ba21ae202da65ba8b77466e6d598e31990790"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
+"checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "514f0d73e64be53ff320680ca671b64fe3fb91da01e1ae2ddc99eb51d453b20d"
 "checksum objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "877f30f37acef6749b1841cceab289707f211aecfc756553cd63976190e6cc2e"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
@@ -1593,25 +1692,32 @@ dependencies = [
 "checksum pistoncore-window 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32a9c9c708945c6e7064ed271be93a246e4c0b19eefe4d70ba38c9978c93abed"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum png 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f0b0cabbbd20c2d7f06dbf015e06aad59b6ca3d9ed14848783e98af9aaf19925"
+"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "61efcbcd9fa8d8fbb07c84e34a8af18a1ff177b449689ad38a6e9457ecc7b2ae"
 "checksum rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b614fe08b6665cb9a231d07ac1364b0ef3cb3698f1239ee0c4c3a88a524f54c8"
 "checksum rayon-core 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7febc28567082c345f10cddc3612c6ea020fc3297a1977d472cf9fdb73e6e493"
 "checksum read_color 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "682bfa200630193df2954f2632b690c4643563fd6abc575edc1239bcfe57ad83"
 "checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
 "checksum regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5be5347bde0c48cfd8c3fdc0766cdfe9d8a755ef84d620d6794c778c91de8b2b"
+"checksum regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5bbbea44c5490a1e84357ff28b7d518b4619a159fed5d25f6c1de2d19cc42814"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
-"checksum rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a3d45d7afc9b132b34a2479648863aa95c5c88e98b32285326a6ebadc80ec5c9"
-"checksum rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "011e1d58446e9fa3af7cdc1fb91295b10621d3ac4cb3a85cc86385ee9ca50cd3"
+"checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
+"checksum rmp 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f594cb7ff8f1c5a7907f6be91f15795c8301e0d5718eb007fb5832723dd716e"
+"checksum rmp-serde 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4a31c0798045f039ace94e0166f76478b3ba83116ec7c9d4bc934c5b13b8df21"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusttype 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "30047cc747a78ae042bf2cd65c79f83c3485d90107535b532d6e8f60e2c89cb1"
 "checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
 "checksum scoped_threadpool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4ea459fe3ceff01e09534847c49860891d3ff1c12b4eb7731b67f2778fb60190"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum sdl2 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63066036ad426250ac56d23e38fd05063b38b661556acd596f4046cc92d98415"
 "checksum sdl2-sys 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b48638b7882759f3421038fcd38ad5f1ea19b119d80c99f1601933004629e34d"
+"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
-"checksum serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "395993cac4e3599c7c1b70a6a92d3b3f55f4443df9f0b5294e362285ad7c9ecb"
+"checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 "checksum serde_derive 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "7fa060f679fe2d5a9f7374dd4553dc907eba4f9acf183e4c7baf69eae02e6ca8"
 "checksum serde_derive_internals 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd381f6d01a6616cdba8530492d453b7761b456ba974e98768a18cad2cd76f58"
 "checksum serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ad8bcf487be7d2e15d3d543f04312de991d631cfe1b43ea0ade69e6a8a5b16a1"
@@ -1626,6 +1732,7 @@ dependencies = [
 "checksum streaming-stats 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "f13d0cd680e11a62c5e125d9799debfb39fcfff9a2ef416336ce748f65018b89"
 "checksum syn 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)" = "58fd09df59565db3399efbba34ba8a2fec1307511ebd245d0061ff9d42691673"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum target_build_utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "013d134ae4a25ee744ad6129db589018558f620ddfa44043887cdd45fa08e75c"
 "checksum tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11ce2fe9db64b842314052e2421ac61a73ce41b898dc8e3750398b219c5fc1e0"
@@ -1634,6 +1741,7 @@ dependencies = [
 "checksum tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "514aae203178929dbf03318ad7c683126672d4d96eccb77b29603d33c9e25743"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6717129de5ac253f5642fc78a51d0c7de6f9f53d617fc94e9bae7f6e71cf5504"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"

--- a/tunnelclient/Cargo.toml
+++ b/tunnelclient/Cargo.toml
@@ -16,7 +16,7 @@ pistoncore-glutin_window = "^0.42.0"
 piston2d-opengl_graphics = "^0.49.0"
 interpolation = "0.1.0"
 yaml-rust = "0.3.5"
-rmp-serde = "0.13.7"
+rmp-serde = "0.14.0"
 serde = "^1"
 serde_derive = "^1"
 streaming-stats = "0.1.28"
@@ -26,6 +26,7 @@ zero_configure = { path = "../zero_configure" }
 regex = "0.2.6"
 lazy_static = "^1"
 hostname = "0.1.4"
+derive_more = "0.15.0"
 
 [dependencies.pistoncore-sdl2_window]
 git = "https://github.com/PistonDevelopers/sdl2_window"

--- a/tunnelclient/cfg/monitor.yaml
+++ b/tunnelclient/cfg/monitor.yaml
@@ -1,5 +1,5 @@
 server_hostname: "127.0.0.1"
-render_delay: 40
+render_delay: 0.040
 timesync_interval: 60000
 x_resolution: 960
 y_resolution: 540

--- a/tunnelclient/cfg/test.yaml
+++ b/tunnelclient/cfg/test.yaml
@@ -1,5 +1,5 @@
 server_hostname: "127.0.0.1"
-render_delay: 40
+render_delay: 0.040
 timesync_interval: 60000
 x_resolution: 1920
 y_resolution: 1080

--- a/tunnelclient/src/config.rs
+++ b/tunnelclient/src/config.rs
@@ -5,6 +5,7 @@ use std::io::Read;
 use std::cmp;
 use std::time::Duration;
 use std::error::Error;
+use timesync::Seconds;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ClientConfig {
@@ -12,8 +13,8 @@ pub struct ClientConfig {
     pub server_hostname: String,
     /// Virtual video channel to listen to.
     pub video_channel: u64,
-    /// Delay between current time and time to render, in floating-point milliseconds.
-    pub render_delay: f64,
+    /// Delay between current time and time to render.
+    pub render_delay: Seconds,
     /// Delay between host/client time synchronization updates.
     pub timesync_interval: Duration,
     pub x_resolution: u32,
@@ -44,7 +45,7 @@ impl ClientConfig {
             host: String,
             resolution: Resolution,
             timesync_interval: Duration,
-            render_delay: f64,
+            render_delay: Seconds,
             anti_alias: bool,
             fullscreen: bool,
             alpha_blend: bool,
@@ -97,7 +98,7 @@ impl ClientConfig {
             host,
             (x_resolution, y_resolution),
             timesync_interval,
-            cfg["render_delay"].as_i64().ok_or("Bad render delay.")? as f64,
+            Seconds(cfg["render_delay"].as_f64().ok_or("Bad render delay.")?),
             flag("anti_alias", "Bad anti-alias flag.")?,
             flag("fullscreen", "Bad fullscreen flag.")?,
             flag("alpha_blend", "Bad alpha blend flag.")?,

--- a/tunnelclient/src/main.rs
+++ b/tunnelclient/src/main.rs
@@ -1,12 +1,7 @@
-#[macro_use]
-extern crate serde_derive;
-
-#[macro_use]
-extern crate simple_error;
-
-#[macro_use]
-extern crate lazy_static;
-
+#[macro_use] extern crate serde_derive;
+#[macro_use] extern crate simple_error;
+#[macro_use] extern crate lazy_static;
+#[macro_use] extern crate derive_more;
 extern crate piston_window;
 extern crate interpolation;
 extern crate graphics;

--- a/tunnelclient/src/receive.rs
+++ b/tunnelclient/src/receive.rs
@@ -11,6 +11,7 @@ use std::sync::mpsc::{Receiver, channel};
 use std::thread;
 use std::error::Error;
 use utils::{almost_eq, angle_almost_eq};
+use timesync::Microseconds;
 
 // --- types used for communication with host server ---
 
@@ -79,7 +80,7 @@ pub type LayerCollection = Vec<Vec<ArcSegment>>;
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 pub struct Snapshot {
     pub frame_number: u64,
-    pub time: u64, // ms
+    pub time: Microseconds,
     pub layers: LayerCollection,
 }
 

--- a/tunnelclient/src/remote.rs
+++ b/tunnelclient/src/remote.rs
@@ -19,6 +19,7 @@ use std::io::{stdin, stdout, Write};
 use std::sync::mpsc::{channel, Sender};
 use regex::Regex;
 use hostname::get_hostname;
+use timesync::Seconds;
 
 const SERVICE_NAME: &'static str = "tunnelclient";
 const PORT: u16 = 15000;
@@ -226,6 +227,11 @@ fn parse_uint(s: &str) -> Result<u64, String> {
     s.parse().map_err(|e| format!("Could not parse '{}' as positive integer: {}", s, e))
 }
 
+/// Parse string as float.
+fn parse_f64(s: &str) -> Result<f64, String> {
+    s.parse().map_err(|e| format!("Could not parse '{}' as float: {}", s, e))
+}
+
 /// Interactive series of user prompts, producing a configuration.
 fn configure_one<H>(hostname: H) -> ClientConfig
     where H: Into<String>
@@ -238,7 +244,7 @@ fn configure_one<H>(hostname: H) -> ClientConfig
     // Some defaults we might configure in advanced mode.
     let mut anti_alias = true;
     let mut timesync_interval = Duration::from_secs(60);
-    let mut render_delay = 40.;
+    let mut render_delay = 0.040;
     let mut alpha_blend = true;
     let mut capture_mouse = true;
 
@@ -250,7 +256,7 @@ fn configure_one<H>(hostname: H) -> ClientConfig
             "Host/client time resynchronization interval in seconds (default 60)",
             parse_uint);
         timesync_interval = Duration::from_secs(timesync_interval_secs);
-        render_delay = prompt("Client render delay in milliseconds (default 40)", parse_uint) as f64;
+        render_delay = prompt("Client render delay in seconds (default 0.040)", parse_f64);
     }
 
     ClientConfig::new(
@@ -258,7 +264,7 @@ fn configure_one<H>(hostname: H) -> ClientConfig
         hostname.into(),
         resolution,
         timesync_interval,
-        render_delay,
+        Seconds(render_delay),
         anti_alias,
         fullscreen,
         alpha_blend,

--- a/tunnelclient/src/show.rs
+++ b/tunnelclient/src/show.rs
@@ -57,9 +57,9 @@ impl Show {
                 thread::sleep(timesync_period);
                 match timesync_client.synchronize() {
                     Ok(sync) => {
-                        let new_estimate = sync.now_as_timestamp();
+                        let new_estimate = sync.now();
                         let mut synchronizer = timesync_remote.lock().expect("Timesync mutex poisoned.");
-                        let old_estimate = synchronizer.now_as_timestamp();
+                        let old_estimate = synchronizer.now();
                         println!(
                             "Updating time sync.  Change from previous estimate: {}",
                             new_estimate - old_estimate);
@@ -83,7 +83,7 @@ impl Show {
         let opengl = OpenGL::V3_2;
 
         // Sleep for a render delay to make sure we have snapshots before we start rendering.
-        thread::sleep(Duration::from_millis(cfg.render_delay as u64));
+        thread::sleep(cfg.render_delay.as_duration());
 
         // Create the window.
         let mut window: PistonWindow<Sdl2Window> = WindowSettings::new(
@@ -150,7 +150,7 @@ impl Show {
                 println!("Timesync service crashed; aborting show.");
                 return
             },
-            Ok(ref mut ts) => ts.now_as_timestamp() - self.cfg.render_delay as f64,
+            Ok(ref mut ts) => ts.now() - self.cfg.render_delay,
         };
 
         let (msg, maybe_frame) = match self.snapshot_manager.get_interpolated(delayed_time) {

--- a/tunnelclient/src/snapshot_manager.rs
+++ b/tunnelclient/src/snapshot_manager.rs
@@ -135,9 +135,10 @@ impl SnapshotManager {
                         let newer_time = newer.time.0 as f64;
                         let alpha = (time.0 as f64 - older_time) / (newer_time - older_time);
 
-                        let interpolation_result = older.layers.interpolate_with(&newer.layers, alpha);
+                        //let interpolation_result = older.layers.interpolate_with(&newer.layers, alpha);
+                        
                         self.oldest_relevant_snapshot_time = older.time;
-                        return InterpResult::Good(interpolation_result);
+                        return InterpResult::Good(newer.layers.clone());
                     }
                 }
                 InterpResult::Error(Vec::from(snaps.clone()))

--- a/tunnelclient/src/snapshot_manager.rs
+++ b/tunnelclient/src/snapshot_manager.rs
@@ -212,16 +212,16 @@ mod tests {
     fn test_drop_stale() {
         let (_, mut sm) = setup_sm();
         let snaps = [
-            mksnapshot(0, Microseconds(0000)),
+            mksnapshot(0, Microseconds(0)),
             mksnapshot(1, Microseconds(1000)),
             mksnapshot(2, Microseconds(2000)),
         ];
         for s in &snaps {sm.insert_snapshot(s.clone());}
-        sm.oldest_relevant_snapshot_time = Microseconds(2);
+        sm.oldest_relevant_snapshot_time = Microseconds(2000);
         sm.drop_stale_snapshots();
 
         assert!(sm.snapshots.len() == 1);
-        assert!(sm.snapshots[0].time.0 == 2);
+        assert!(sm.snapshots[0].time.0 == 2000);
     }
 
     #[test]
@@ -236,7 +236,7 @@ mod tests {
         let (_, mut sm) = setup_sm();
         let snap = mksnapshot_with_arc(0, Microseconds(0), ArcSegment::for_test(0.2, 0.3));
         sm.insert_snapshot(snap.clone());
-        if let MissingNewer(f) = sm.get_interpolated(Seconds(1.0)) {
+        if let MissingNewer(f) = sm.get_interpolated(Seconds(0.001)) {
             assert_eq!(snap.layers, f);
         }
         else {panic!();}
@@ -247,7 +247,7 @@ mod tests {
         let (_, mut sm) = setup_sm();
         let snap = mksnapshot_with_arc(0, Microseconds(10000), ArcSegment::for_test(0.2, 0.3));
         sm.insert_snapshot(snap.clone());
-        if let MissingOlder(f) = sm.get_interpolated(Seconds(1.0)) {
+        if let MissingOlder(f) = sm.get_interpolated(Seconds(0.001)) {
             assert_eq!(snap.layers, f);
         }
         else {panic!();}
@@ -265,7 +265,7 @@ mod tests {
     #[test]
     fn test_interp_two_frames_exact_newer() {
         let (mut sm, _snap0, snap1) = setup_two_frame_test();
-        if let Good(f) = sm.get_interpolated(Seconds(10.0)) {
+        if let Good(f) = sm.get_interpolated(Seconds(0.001)) {
             assert_eq!(snap1.layers, f);
         }
         else {panic!();}
@@ -283,7 +283,7 @@ mod tests {
     #[test]
     fn test_interp_two_frames_middle() {
         let (mut sm, snap0, snap1) = setup_two_frame_test();
-        if let Good(f) = sm.get_interpolated(Seconds(5.0)) {
+        if let Good(f) = sm.get_interpolated(Seconds(0.005)) {
             assert_eq!(snap0.layers.interpolate_with(&snap1.layers, 0.0), f);
         }
         else {panic!();}

--- a/tunnelz/clock.py
+++ b/tunnelz/clock.py
@@ -126,8 +126,8 @@ class Clock (object):
             self.curr_angle = 0.0
             self.reset_on_update = False
         else:
-            # delta_t has units of ms, need to divide by 1000
-            new_angle = self.curr_angle + (self.rate*delta_t/1000.)
+            # delta_t has units of us, need to divide by 1000000
+            new_angle = self.curr_angle + (self.rate*delta_t/1000000.)
 
             # if we're running in one-shot mode, clamp the angle at 1.0
             if self.one_shot and new_angle >= 1.0:

--- a/tunnelz/show.py
+++ b/tunnelz/show.py
@@ -109,11 +109,11 @@ class Show (object):
 
         # show is ready to run
 
-    def run(self, update_interval=16, n_frames=None):
+    def run(self, update_interval=16667, n_frames=None):
         """Run the show loop.
 
         Args:
-            update_interval (int): number of milliseconds between beam state updates
+            update_interval (int): number of microseconds between beam state updates
             n_frames (None or int): if None, run forever.  if finite number, only
                 run for this many state updates.
         """
@@ -134,9 +134,9 @@ class Show (object):
         render_server.start()
         log.info("Render server started.")
 
-        time_millis = lambda: int(monotonic()*1000)
+        time_micros = lambda: int(monotonic()*1000000)
 
-        last_update = time_millis()
+        last_update = time_micros()
 
         last_rendered_frame = -1
 
@@ -144,14 +144,14 @@ class Show (object):
             while n_frames is None or update_number < n_frames:
                 try:
                     # compute updates until we're current
-                    now = time_millis()
+                    now = time_micros()
                     time_since_last_update = now - last_update
 
                     while time_since_last_update > update_interval:
                         self._update_state(update_interval)
 
                         last_update += update_interval
-                        now = time_millis()
+                        now = time_micros()
                         time_since_last_update = now - last_update
                         update_number += 1
 
@@ -165,7 +165,7 @@ class Show (object):
 
                     # process a control event for a fraction of the time between now
                     # and when we will need to update state again
-                    now = time_millis()
+                    now = time_micros()
 
                     time_to_next_update = last_update + update_interval - now
 

--- a/tunnelz/show.py
+++ b/tunnelz/show.py
@@ -329,7 +329,7 @@ class Show (object):
         tunnel = layer.beam
 
         tunnel.rot_speed = 0.0
-        tunnel.marquee_speed = 0.05
+        tunnel.marquee_speed = 1.0
 
     def setup_multi_channel_test(self):
         """Set up eight unique tunnels, one per video output."""

--- a/tunnelz/show.py
+++ b/tunnelz/show.py
@@ -173,7 +173,7 @@ class Show (object):
                         # timeout arg is a float in seconds
                         # only use, say, 80% of the time we have to prioritize
                         # timely state updates
-                        timeout = 0.8 * time_to_next_update / 1000.
+                        timeout = 0.8 * time_to_next_update / 10000000.
                         self._service_control_event(timeout)
                 except Exception:
                     if self.test_mode:

--- a/tunnelz/tunnel.py
+++ b/tunnelz/tunnel.py
@@ -149,7 +149,7 @@ class Tunnel (Beam):
         """Update the state of this tunnel in preparation for drawing a frame.
 
         Args:
-            delta_t (int): evolution time in milliseconds
+            delta_t (int): evolution time in microseconds
             external_clocks: collection of external clocks that may be used by
                 this beam's animators.
         """
@@ -183,16 +183,16 @@ class Tunnel (Beam):
         # calulcate the rotation, wrap to 0 to 1
         self.curr_rot_angle = (
             (self.curr_rot_angle +
-            # delta_t*0.03 implies the same speed scale as we had at 30fps with evolution tied to frame
+            # delta_t*0.00003 implies the same speed scale as we had at 30fps with evolution tied to frame
             # square rot speed control parameter for more slow resolution
-            (scale_speed(self.rot_speed)*delta_t*0.03 + rot_angle_adjust)*self.rot_speed_scale)) % 1.0
+            (scale_speed(self.rot_speed)*delta_t*0.00003 + rot_angle_adjust)*self.rot_speed_scale)) % 1.0
 
         # calulcate the marquee angle, wrap to 0 to 1
         self.curr_marquee_angle = (
             (self.curr_marquee_angle +
-            # delta_t*0.03 implies the same speed scale as we had at 30fps with evolution tied to frame
+            # delta_t*0.00003 implies the same speed scale as we had at 30fps with evolution tied to frame
             # square marquee speed control parameter for more slow resolution
-            (scale_speed(self.marquee_speed)*delta_t*0.03 + marquee_angle_adjust)*self.marquee_speed_scale)) % 1.0
+            (scale_speed(self.marquee_speed)*delta_t*0.00003 + marquee_angle_adjust)*self.marquee_speed_scale)) % 1.0
 
     def display(self, level_scale, as_mask, external_clocks):
         """Return the current state of the beam.

--- a/zero_configure/src/lib.rs
+++ b/zero_configure/src/lib.rs
@@ -30,7 +30,7 @@ fn reg_type(name: &str) -> String { format!("_{}._tcp", name) }
 /// Advertise a service over DNS-SD, using a 0mq REQ/REP socket as the subsequent transport.
 /// Pass each message received on the socket to the action callback.  Send the byte buffer returned
 /// by the action callback back to the requester.
-pub fn run_service<F>(name: &str, port: u16, mut action: F) -> Result<(), Box<Error>>
+pub fn run_service<F>(name: &str, port: u16, mut action: F) -> Result<(), Box<dyn Error>>
     where F: FnMut(&[u8]) -> Vec<u8>
 {
 
@@ -154,7 +154,7 @@ impl Controller {
     }
 
     /// Send a message to one of the services on this controller, returning the response.
-    pub fn send(&self, name: &str, msg: &[u8]) -> Result<Vec<u8>, Box<Error>> {
+    pub fn send(&self, name: &str, msg: &[u8]) -> Result<Vec<u8>, Box<dyn Error>> {
         let services = self.services.lock().unwrap();
         let socket = match services.get(name) {
             None => bail!(format!("No service named '{}' available.", name)),
@@ -167,7 +167,7 @@ impl Controller {
 }
 
 /// Try to connect a REQ socket at this host and port.
-fn req_socket(host: &str, port: u16, ctx: &mut Context) -> Result<Socket, Box<Error>> {
+fn req_socket(host: &str, port: u16, ctx: &mut Context) -> Result<Socket, Box<dyn Error>> {
 
     let addr = format!("tcp://{}:{}", host, port);
 


### PR DESCRIPTION
Replaces all use of integer milliseconds with integer microseconds, providing framerates much closer to 60 fps (16667 microseconds per frame instead of 16 or 17 milliseconds).  Extensively refactors the use of time in the Rust client to exclusively deal in newtypes to clean up bare f64s.