### PR TITLE
Client transforms

### DIFF
--- a/tunnelclient/cfg/monitor.yaml
+++ b/tunnelclient/cfg/monitor.yaml
@@ -3,6 +3,7 @@ render_delay: 0.040
 timesync_interval: 60000
 x_resolution: 960
 y_resolution: 540
+flip_horizontal: false
 anti_alias: true
 fullscreen: false
 capture_mouse: false

--- a/tunnelclient/cfg/test.yaml
+++ b/tunnelclient/cfg/test.yaml
@@ -3,6 +3,7 @@ render_delay: 0.040
 timesync_interval: 60000
 x_resolution: 1920
 y_resolution: 1080
+flip_horizontal: false
 anti_alias: true
 fullscreen: false
 capture_mouse: false

--- a/tunnelclient/src/config.rs
+++ b/tunnelclient/src/config.rs
@@ -6,6 +6,7 @@ use std::cmp;
 use std::time::Duration;
 use std::error::Error;
 use timesync::Seconds;
+use draw::{Transform, TransformDirection};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ClientConfig {
@@ -35,6 +36,8 @@ pub struct ClientConfig {
     pub x_center: f64,
     /// Computed pixel y-offset of the drawing coordinate system.
     pub y_center: f64,
+    /// Geometric transformation to optionally apply to the entire image.
+    pub transformation: Option<Transform>,
 }
 
 impl ClientConfig {
@@ -50,6 +53,7 @@ impl ClientConfig {
             fullscreen: bool,
             alpha_blend: bool,
             capture_mouse: bool,
+            transformation: Option<Transform>,
     ) -> ClientConfig {
 
         let (x_resolution, y_resolution) = resolution;
@@ -69,6 +73,7 @@ impl ClientConfig {
             x_center: f64::from(x_resolution / 2),
             y_center: f64::from(y_resolution / 2),
             alpha_blend,
+            transformation,
         }
     }
 
@@ -93,6 +98,13 @@ impl ClientConfig {
             cfg[name].as_bool().ok_or(missing)
         };
 
+        let transformation =
+            if flag("flip_horizontal", "Bad horizontal flip flag.")? {
+                Some(Transform::Flip(TransformDirection::Horizontal))
+            } else {
+                None
+            };
+
         Ok(ClientConfig::new(
             video_channel,
             host,
@@ -103,6 +115,7 @@ impl ClientConfig {
             flag("fullscreen", "Bad fullscreen flag.")?,
             flag("alpha_blend", "Bad alpha blend flag.")?,
             flag("capture_mouse", "Bad mouse capture flag.")?,
+            transformation,
         ))
     }
 

--- a/tunnelclient/src/remote.rs
+++ b/tunnelclient/src/remote.rs
@@ -20,6 +20,7 @@ use std::sync::mpsc::{channel, Sender};
 use regex::Regex;
 use hostname::get_hostname;
 use timesync::Seconds;
+use draw::{Transform, TransformDirection};
 
 const SERVICE_NAME: &str = "tunnelclient";
 const PORT: u16 = 15000;
@@ -242,6 +243,12 @@ fn configure_one<H>(hostname: H) -> ClientConfig
     let resolution = prompt(
         "Specify display resolution (widthxheight or heightp for 16:9)", parse_resolution);
     let fullscreen = prompt_y_n("Fullscreen");
+    let transformation =
+        if prompt_y_n("Flip horizontal") {
+            Some(Transform::Flip(TransformDirection::Horizontal))
+        } else {
+            None
+        };
 
     // Some defaults we might configure in advanced mode.
     let mut anti_alias = true;
@@ -271,6 +278,7 @@ fn configure_one<H>(hostname: H) -> ClientConfig
         fullscreen,
         alpha_blend,
         capture_mouse,
+        transformation,
     )
 }
 


### PR DESCRIPTION
Adds the ability to flip the entire image horizontally at the config level.  No more reading backwards projector menus!